### PR TITLE
作成日を読みやすい形式に変更 #28

### DIFF
--- a/src/components/drawList.tsx
+++ b/src/components/drawList.tsx
@@ -34,6 +34,11 @@ export default function DrawList({
     );
   }
 
+  const drawDate = (date: string) => {
+    const dateString = new Date(date);
+    return dateString.toLocaleString('ja');
+  };
+
   return (
     <div className="p-5 w-full">
       <div className="w-full p-3 flex flex-row items-center border-zinc-300 border-b-2">
@@ -74,7 +79,7 @@ export default function DrawList({
                 />
                 <p>{ele.title}</p>
               </button>
-              <p className="basis-5/12">{ele.created_at}</p>
+              <p className="basis-5/12">{drawDate(ele.created_at)}</p>
             </div>
           );
         })
@@ -112,7 +117,7 @@ export default function DrawList({
                 />
                 <p>{ele.title}</p>
               </Link>
-              <p className="basis-5/12">{ele.created_at}</p>
+              <p className="basis-5/12">{drawDate(ele.created_at)}</p>
             </div>
           );
         })


### PR DESCRIPTION
![スクリーンショット 2023-11-04 101730](https://github.com/motsu8/youtube_note/assets/80054036/e1cfae35-a5ee-4784-82ed-8a414e7821ad)
